### PR TITLE
Handle pre-release versions during `skyux upgrade`

### DIFF
--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -160,7 +160,12 @@ async function upgradeDependencies(dependencies) {
       let dependencyPromise;
 
       if (/^[0-9]+\./.test(currentVersion)) {
-        const majorVersion = currentVersion.split('.')[0];
+        let majorVersion = currentVersion.split('.')[0];
+
+        // Handle prerelease versions.
+        if (/-(rc|alpha|beta)\./.test(currentVersion)) {
+          majorVersion = `^${currentVersion}`;
+        }
 
         logger.info(`Getting latest ${packageName} version for major version ${majorVersion}...`);
 

--- a/spec/lib/app-dependencies.spec.js
+++ b/spec/lib/app-dependencies.spec.js
@@ -163,6 +163,41 @@ describe('App dependencies', () => {
       expect(dependencies).toBeUndefined();
     });
 
+    it('should handle prerelease versions', async () => {
+      await appDependencies.upgradeDependencies({
+        'prerelease-foo': '1.0.0-rc.0'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith(
+        'prerelease-foo',
+        {
+          version: '^1.0.0-rc.0'
+        }
+      );
+
+      await appDependencies.upgradeDependencies({
+        'prerelease-foo': '1.0.0-alpha.0'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith(
+        'prerelease-foo',
+        {
+          version: '^1.0.0-alpha.0'
+        }
+      );
+
+      await appDependencies.upgradeDependencies({
+        'prerelease-foo': '1.0.0-beta.0'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith(
+        'prerelease-foo',
+        {
+          version: '^1.0.0-beta.0'
+        }
+      );
+    });
+
   });
 
   describe('addSkyPeerDependencies() method', () => {


### PR DESCRIPTION
Currently, if the **package.json** file includes a package with a pre-release version, the `skyux upgrade` command throws an uncaught error.