### PR TITLE
Add support for migrating Stache sites

### DIFF
--- a/cli/migrate.js
+++ b/cli/migrate.js
@@ -193,7 +193,10 @@ async function migrate() {
   );
 
   // Update package.json dependencies and devDependencies.
-  const dependencies = await appDependencies.createPackageJsonDependencies(packageList, isStacheSpa);
+  const dependencies = await appDependencies.createPackageJsonDependencies(
+    packageList,
+    isStacheSpa
+  );
 
   await writePackageJson(packageJson, isLib, dependencies, packageList);
 

--- a/cli/migrate.js
+++ b/cli/migrate.js
@@ -180,17 +180,10 @@ async function migrate() {
 
   if (isStacheSpa) {
     await stacheUtils.renameDeprecatedComponents();
+    await stacheUtils.updateStacheImportPaths();
   }
 
   const packageList = await packageMap.createPackageList();
-
-  // Create Angular module file.
-  const moduleSource = appSkyModule.createAppSkyModule(isLib, packageList);
-
-  await fs.writeFile(
-    path.join('src', 'app', 'app-sky.module.ts'),
-    moduleSource
-  );
 
   // Update package.json dependencies and devDependencies.
   const dependencies = await appDependencies.createPackageJsonDependencies(
@@ -199,6 +192,19 @@ async function migrate() {
   );
 
   await writePackageJson(packageJson, isLib, dependencies, packageList);
+
+  // Create Angular module file.
+  if (isStacheSpa) {
+    // Don't include StacheModule in the AppSkyModule.
+    delete packageList['@blackbaud/skyux-lib-stache'];
+  }
+
+  const moduleSource = appSkyModule.createAppSkyModule(isLib, packageList);
+
+  await fs.writeFile(
+    path.join('src', 'app', 'app-sky.module.ts'),
+    moduleSource
+  );
 
   await updateAppExtras();
 

--- a/cli/migrate.js
+++ b/cli/migrate.js
@@ -16,6 +16,7 @@ const webpack = require('../lib/webpack');
 const nvmrc = require('../lib/nvmrc');
 const gitignore = require('../lib/gitignore');
 const cleanup = require('../lib/cleanup');
+const stacheUtils = require('../lib/stache');
 
 async function getPackageJson() {
   const packageJson = await jsonUtils.readJson('package.json');
@@ -49,6 +50,7 @@ async function writePackageJson(packageJson, isLib, dependencies, packageList) {
 
   removeDependency(packageJson, '@blackbaud/skyux');
   removeDependency(packageJson, '@blackbaud/skyux-builder');
+  removeDependency(packageJson, '@blackbaud/stache');
 
   for (const dependency of sortUtils.sortedKeys(dependencies.dependencies)) {
     if (isLib) {
@@ -174,6 +176,12 @@ async function migrate() {
 
   const isLib = packageJson.name.indexOf('/skyux-lib') >= 0;
 
+  const isStacheSpa = (packageJson.dependencies['@blackbaud/stache'] !== undefined);
+
+  if (isStacheSpa) {
+    await stacheUtils.renameDeprecatedComponents();
+  }
+
   const packageList = await packageMap.createPackageList();
 
   // Create Angular module file.
@@ -185,7 +193,7 @@ async function migrate() {
   );
 
   // Update package.json dependencies and devDependencies.
-  const dependencies = await appDependencies.createPackageJsonDependencies(packageList);
+  const dependencies = await appDependencies.createPackageJsonDependencies(packageList, isStacheSpa);
 
   await writePackageJson(packageJson, isLib, dependencies, packageList);
 

--- a/cli/migrate.js
+++ b/cli/migrate.js
@@ -176,7 +176,10 @@ async function migrate() {
 
   const isLib = packageJson.name.indexOf('/skyux-lib') >= 0;
 
-  const isStacheSpa = (packageJson.dependencies['@blackbaud/stache'] !== undefined);
+  const isStacheSpa = (
+    packageJson.dependencies['@blackbaud/stache'] ||
+    packageJson.dependencies['@blackbaud/skyux-lib-stache']
+  );
 
   if (isStacheSpa) {
     await stacheUtils.renameDeprecatedComponents();

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -4,6 +4,7 @@ const logger = require('@blackbaud/skyux-logger');
 
 const packageMap = require('./package-map');
 const sortUtils = require('../lib/sort-utils');
+const stacheUtils = require('../lib/stache');
 
 /**
  * Alphabetizes dependencies, similar to the behavior of `npm install <package> --save`.
@@ -137,8 +138,7 @@ async function createPackageJsonDependencies(packageList, isStacheSpa = false) {
   };
 
   if (isStacheSpa) {
-    dependencies['@blackbaud/skyux-lib-stache'] = 'latest';
-    devDependencies['@blackbaud/skyux-builder-stache-search'] = 'latest';
+    stacheUtils.modifyDependencies(dependencies, devDependencies);
   }
 
   for (const packageName of Object.keys(packageList)) {

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -160,7 +160,12 @@ async function upgradeDependencies(dependencies) {
       let dependencyPromise;
 
       if (/^[0-9]+\./.test(currentVersion)) {
-        const majorVersion = currentVersion.split('.')[0];
+        let majorVersion = currentVersion.split('.')[0];
+
+        // Handle prerelease versions.
+        if (/-(rc|alpha|beta)\./.test(currentVersion)) {
+          majorVersion = `^${currentVersion}`;
+        }
 
         logger.info(`Getting latest ${packageName} version for major version ${majorVersion}...`);
 

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -146,11 +146,11 @@ async function createPackageJsonDependencies(packageList, isStacheSpa = false) {
   await upgradeDependencies(dependencies);
   await upgradeDependencies(devDependencies);
 
-  // Run it once more to get peers from peers.
-  await upgradeDependencies(dependencies);
-
   await addSkyPeerDependencies(dependencies);
   await addSkyPeerDependencies(devDependencies);
+
+  // Run it once more to get peers from peers.
+  await addSkyPeerDependencies(dependencies);
 
   logger.info('Getting latest versions for SKY UX packages...');
 

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -138,7 +138,8 @@ async function createPackageJsonDependencies(packageList, isStacheSpa = false) {
   };
 
   if (isStacheSpa) {
-    stacheUtils.modifyDependencies(dependencies, devDependencies);
+    dependencies['@blackbaud/skyux-lib-stache'] = 'latest';
+    devDependencies['@blackbaud/skyux-builder-stache-search'] = 'latest';
   }
 
   for (const packageName of Object.keys(packageList)) {

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -130,10 +130,22 @@ async function createPackageJsonDependencies(packageList, isStacheSpa = false) {
 
   if (isStacheSpa) {
     dependencies['@blackbaud/skyux-lib-stache'] = 'latest';
+    devDependencies['@blackbaud/skyux-builder-stache-search'] = 'latest';
   }
 
   for (const packageName of Object.keys(packageList)) {
-    if (!packageMap.getPackage(packageName).skipInstall) {
+    const packageConfig = packageMap.getPackage(packageName);
+    const builderPlugins = packageConfig.builderPlugins;
+
+    // Add any Builder plugins to dev dependencies.
+    if (builderPlugins) {
+      builderPlugins.forEach((plugin) => {
+        delete dependencies[plugin];
+        devDependencies[plugin] = 'latest';
+      });
+    }
+
+    if (!packageConfig.skipInstall) {
       const dependenciesToUpdate = packageName.indexOf('@skyux-sdk/') === 0 ? devDependencies : dependencies;
 
       dependenciesToUpdate[packageName] = 'latest';

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -54,9 +54,12 @@ async function setDependencyVersions(dependencies) {
  */
 async function addSkyPeerDependencies(dependencies) {
   if (dependencies) {
-    const skyPackageNames = Object.keys(dependencies).filter(
-      packageName => packageName.indexOf('@skyux/') === 0
-    );
+    const skyPackageNames = Object.keys(dependencies).filter((packageName) => {
+      return (
+        packageName.indexOf('@skyux/') === 0 ||
+        packageName.indexOf('@blackbaud/skyux-lib-') === 0
+      );
+    });
 
     const peerPromises = skyPackageNames.map(
       packageName => getPackageJson(packageName)
@@ -102,6 +105,7 @@ async function createPackageJsonDependencies(packageList, isStacheSpa = false) {
     '@skyux/core': 'latest',
     '@skyux/http': 'latest',
     '@skyux/i18n': 'latest',
+    '@skyux/modals': 'latest',
     '@skyux/omnibar-interop': 'latest',
     '@skyux/router': 'latest',
     '@skyux/theme': 'latest',
@@ -138,13 +142,21 @@ async function createPackageJsonDependencies(packageList, isStacheSpa = false) {
 
   logger.info('Adding peer dependencies for SKY UX packages...');
 
+  // First upgrade the packages to make sure we get the latest peer dependencies.
+  await upgradeDependencies(dependencies);
+  await upgradeDependencies(devDependencies);
+
+  // Run it once more to get peers from peers.
+  await upgradeDependencies(dependencies);
+
   await addSkyPeerDependencies(dependencies);
   await addSkyPeerDependencies(devDependencies);
 
   logger.info('Getting latest versions for SKY UX packages...');
 
-  await setDependencyVersions(dependencies);
-  await setDependencyVersions(devDependencies);
+  // Finally, upgrade any packages that were added in the previous step.
+  await upgradeDependencies(dependencies);
+  await upgradeDependencies(devDependencies);
 
   return {
     dependencies,
@@ -200,6 +212,7 @@ async function upgradeDependencies(dependencies) {
             logger.info(`Updating package ${packageName} to version ${versionNumber}`);
             dependencies[packageName] = versionNumber;
           }
+          break;
       }
     });
   }

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -86,7 +86,7 @@ async function addSkyPeerDependencies(dependencies) {
  * given the packages that match the SKY UX components and types used by the application.
  * @param {*} packageList The list of packages to be installed for the application.
  */
-async function createPackageJsonDependencies(packageList) {
+async function createPackageJsonDependencies(packageList, isStacheSpa = false) {
   const dependencies = {
     '@angular/animations': '7.2.2',
     '@angular/common': '7.2.2',
@@ -123,6 +123,10 @@ async function createPackageJsonDependencies(packageList) {
     'tslint': '5.12.1',
     'typescript': '3.2.4'
   };
+
+  if (isStacheSpa) {
+    dependencies['@blackbaud/skyux-lib-stache'] = 'latest';
+  }
 
   for (const packageName of Object.keys(packageList)) {
     if (!packageMap.getPackage(packageName).skipInstall) {

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -212,7 +212,6 @@ async function upgradeDependencies(dependencies) {
             logger.info(`Updating package ${packageName} to version ${versionNumber}`);
             dependencies[packageName] = versionNumber;
           }
-          break;
       }
     });
   }

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -53,6 +53,8 @@ async function setDependencyVersions(dependencies) {
  * @param {*} dependencies List of top-level dependencies.
  */
 async function addSkyPeerDependencies(dependencies) {
+  let foundNewDependency = false;
+
   if (dependencies) {
     const skyPackageNames = Object.keys(dependencies).filter((packageName) => {
       return (
@@ -73,6 +75,7 @@ async function addSkyPeerDependencies(dependencies) {
           if (!dependencies[peerDependency]) {
             logger.info(`Adding package ${peerDependency} since it is a peer dependency of ${packageJson.name}...`);
             dependencies[peerDependency] = 'latest';
+            foundNewDependency = true;
           }
         }
       }
@@ -82,6 +85,11 @@ async function addSkyPeerDependencies(dependencies) {
   }
 
   fixDependencyOrder(dependencies);
+
+  // New dependencies were added, so we need to run the peer check again.
+  if (foundNewDependency) {
+    addSkyPeerDependencies(dependencies);
+  }
 }
 
 /**
@@ -152,23 +160,17 @@ async function createPackageJsonDependencies(packageList, isStacheSpa = false) {
     }
   }
 
-  logger.info('Adding peer dependencies for SKY UX packages...');
-
-  // First upgrade the packages to make sure we get the latest peer dependencies.
-  await upgradeDependencies(dependencies);
-  await upgradeDependencies(devDependencies);
-
-  await addSkyPeerDependencies(dependencies);
-  await addSkyPeerDependencies(devDependencies);
-
-  // Run it once more to get peers from peers.
-  await addSkyPeerDependencies(dependencies);
-
   logger.info('Getting latest versions for SKY UX packages...');
 
-  // Finally, upgrade any packages that were added in the previous step.
+  // First, upgrade the packages to make sure we get their latest peer dependency requirements.
   await upgradeDependencies(dependencies);
   await upgradeDependencies(devDependencies);
+
+  logger.info('Adding peer dependencies for SKY UX packages...');
+
+  // Add the required peers to this project's dependencies.
+  await addSkyPeerDependencies(dependencies);
+  await addSkyPeerDependencies(devDependencies);
 
   return {
     dependencies,

--- a/lib/import-paths.js
+++ b/lib/import-paths.js
@@ -146,7 +146,7 @@ async function fixImportPaths() {
   const results = await findInFiles.find(
     {
       term: '\\s*import\\s+\\{\\s*[A-z0-9\\s,]+\\}\\s+from\\s+(\'|")' +
-      '(@blackbaud/skyux/[A-z0-9/\\-\\.]*|@blackbaud/skyux-builder/[A-z0-9/\\-]*|@blackbaud/stache)' +
+      '(@blackbaud/skyux/[A-z0-9/\\-\\.]*|@blackbaud/skyux-builder/[A-z0-9/\\-]*)' +
       '(\'|")\\s*;\\s*',
       flags: 'g'
     },

--- a/lib/import-paths.js
+++ b/lib/import-paths.js
@@ -146,7 +146,7 @@ async function fixImportPaths() {
   const results = await findInFiles.find(
     {
       term: '\\s*import\\s+\\{\\s*[A-z0-9\\s,]+\\}\\s+from\\s+(\'|")' +
-      '(@blackbaud/skyux/[A-z0-9/\\-\\.]*|@blackbaud/skyux-builder/[A-z0-9/\\-]*)' +
+      '(@blackbaud/skyux/[A-z0-9/\\-\\.]*|@blackbaud/skyux-builder/[A-z0-9/\\-]*|@blackbaud/stache)' +
       '(\'|")\\s*;\\s*',
       flags: 'g'
     },

--- a/lib/package-map.js
+++ b/lib/package-map.js
@@ -64,6 +64,19 @@ const packageMap = [
     ]
   },
   {
+    package: '@blackbaud/skyux-lib-restricted-view',
+    modules: [
+      {
+        name: 'SkyRestrictedViewModule',
+        matches: [
+          'SkyRestrictedView',
+          'sky-restricted-view',
+          'skyRestrictedView'
+        ]
+      }
+    ]
+  },
+  {
     package: '@blackbaud/skyux-lib-stache',
     modules: [
       {

--- a/lib/package-map.js
+++ b/lib/package-map.js
@@ -6,8 +6,9 @@ const packageMap = [
     package: '@blackbaud/skyux-lib-clipboard',
     modules: [
       {
-        name: 'SkyCopyToClipboardModule',
+        name: 'SkyClipboardModule',
         matches: [
+          'SkyClipboard',
           'SkyCopyToClipboard',
           'sky-copy-to-clipboard'
         ]

--- a/lib/package-map.js
+++ b/lib/package-map.js
@@ -3,6 +3,74 @@ const logger = require('@blackbaud/skyux-logger');
 
 const packageMap = [
   {
+    package: '@blackbaud/skyux-lib-clipboard',
+    modules: [
+      {
+        name: 'SkyCopyToClipboardModule',
+        matches: [
+          'SkyCopyToClipboard',
+          'sky-copy-to-clipboard'
+        ]
+      }
+    ]
+  },
+  {
+    package: '@blackbaud/skyux-lib-code-block',
+    modules: [
+      {
+        name: 'SkyCodeBlockModule',
+        matches: [
+          'SkyCodeBlockModule',
+          'sky-code-block'
+        ]
+      },
+      {
+        name: 'SkyCodeModule',
+        matches: [
+          'SkyCodeModule',
+          'sky-code'
+        ]
+      }
+    ]
+  },
+  {
+    package: '@blackbaud/skyux-lib-media',
+    modules: [
+      {
+        name: 'SkyHeroModule',
+        matches: [
+          'SkyHeroModule',
+          'sky-hero'
+        ]
+      },
+      {
+        name: 'SkyImageModule',
+        matches: [
+          'SkyImageModule',
+          'sky-image'
+        ]
+      },
+      {
+        name: 'SkyVideoModule',
+        matches: [
+          'SkyVideoModule',
+          'sky-video'
+        ]
+      }
+    ]
+  },
+  {
+    package: '@blackbaud/skyux-lib-stache',
+    modules: [
+      {
+        name: 'StacheModule',
+        matches: [
+          'StacheModule'
+        ]
+      }
+    ]
+  },
+  {
     package: '@skyux-sdk/builder',
     skipInstall: true,
     nonModuleMatches: [
@@ -47,8 +115,7 @@ const packageMap = [
     package: '@skyux/assets',
     nonModuleMatches: [
       'SkyAppAssetsService'
-    ],
-
+    ]
   },
   {
     package: '@skyux/colorpicker',

--- a/lib/package-map.js
+++ b/lib/package-map.js
@@ -31,6 +31,9 @@ const packageMap = [
           'sky-code'
         ]
       }
+    ],
+    builderPlugins: [
+      '@blackbaud/skyux-builder-plugin-code-block'
     ]
   },
   {
@@ -68,6 +71,9 @@ const packageMap = [
           'StacheModule'
         ]
       }
+    ],
+    builderPlugins: [
+      '@blackbaud/skyux-builder-plugin-stache'
     ]
   },
   {
@@ -816,7 +822,7 @@ async function createPackageList() {
 
   const results = await findInFiles.find(
     {
-      term:'[Ss]ky[A-z0-9\\-]+',
+      term:'[Ss](ky|tache)[A-z0-9\\-]+',
       flags: 'g'
     },
     'src',

--- a/lib/skyux-config.js
+++ b/lib/skyux-config.js
@@ -1,5 +1,29 @@
 const jsonUtils = require('./json-utils');
 
+async function updatePlugins(config) {
+  const packageJson = await jsonUtils.readJson('package.json');
+
+  const installedPlugins = Object.keys(packageJson.devDependencies).map((packageName) => {
+    return packageName;
+  }).filter((packageName) => {
+    return (
+      packageName.indexOf('@blackbaud/skyux-builder-plugin-') === 0 ||
+      packageName.indexOf('@skyux-sdk/builder-plugin-') === 0
+    );
+  });
+
+  // Update plugins array, from installed plugins.
+  if (!config.plugins) {
+    config.plugins = installedPlugins;
+  } else {
+    installedPlugins.forEach((plugin) => {
+      if (config.plugins.indexOf(plugin) === -1) {
+        config.plugins.push(plugin);
+      }
+    });
+  }
+}
+
 async function updateSkyuxConfig() {
   const config = await jsonUtils.readJson('skyuxconfig.json') || {};
 
@@ -21,6 +45,8 @@ async function updateSkyuxConfig() {
   if (newConfig.app.styles.indexOf(skyCssPath) < 0) {
     newConfig.app.styles.push(skyCssPath);
   }
+
+  await updatePlugins(newConfig);
 
   await jsonUtils.writeJson('skyuxconfig.json', newConfig);
 }

--- a/lib/stache.js
+++ b/lib/stache.js
@@ -4,22 +4,25 @@ const fs = require('fs-extra');
 
 async function renameDeprecatedComponents() {
 
-  const componentSelectors = [
-    'code',
-    'code-block',
-    'column',
-    'copy-to-clipboard',
-    'hero',
-    'hero-heading',
-    'hero-subheading',
-    'image',
-    'row',
-    'video'
-  ].join('|');
+  const componentSelectorMap = {
+    'stache-code-block': 'sky-code-block',
+    'stache-code': 'sky-code',
+    'stache-column': 'sky-column',
+    'stache-copy-to-clipboard': 'sky-copy-to-clipboard',
+    'stache-hero': 'sky-hero',
+    'stache-hero-heading': 'sky-hero-heading',
+    'stache-hero-subheading': 'sky-hero-subheading',
+    'stache-image': 'sky-image',
+    'stache-internal': 'sky-restricted-view',
+    'stache-row': 'sky-row',
+    'stache-video': 'sky-video'
+  };
+
+  const stacheTags = Object.keys(componentSelectorMap);
 
   const results = await findInFiles.find(
     {
-      term: `</?stache-(${componentSelectors})(\\s|>)`,
+      term: `</?(${stacheTags.join('|')})(\\s|>)`,
       flags: 'g'
     },
     'src',
@@ -35,7 +38,12 @@ async function renameDeprecatedComponents() {
     );
 
     matches.forEach((match) => {
-      const replacement = match.replace(/stache/g, 'sky');
+      const stacheTag = stacheTags.find((stacheTag) => {
+        return (match.indexOf(stacheTag) > -1);
+      });
+
+      const regexp = new RegExp(stacheTag, 'g');
+      const replacement = match.replace(regexp, componentSelectorMap[stacheTag]);
 
       logger.info(`Renaming deprecated component from \`${match}\` to \`${replacement}\` in ${fileName}.`);
 
@@ -83,13 +91,7 @@ async function updateStacheImportPaths() {
 
 }
 
-function modifyDependencies(dependencies, devDependencies) {
-  dependencies['@blackbaud/skyux-lib-stache'] = 'latest';
-  devDependencies['@blackbaud/skyux-builder-stache-search'] = 'latest';
-}
-
 module.exports = {
-  modifyDependencies,
   renameDeprecatedComponents,
   updateStacheImportPaths
 };

--- a/lib/stache.js
+++ b/lib/stache.js
@@ -17,7 +17,7 @@ async function renameDeprecatedComponents() {
 
   const results = await findInFiles.find(
     {
-      term: `<\/?stache-(${componentSelectors})(\\s|>)`,
+      term: `</?stache-(${componentSelectors})(\\s|>)`,
       flags: 'g'
     },
     'src',

--- a/lib/stache.js
+++ b/lib/stache.js
@@ -7,11 +7,13 @@ async function renameDeprecatedComponents() {
   const componentSelectors = [
     'code',
     'code-block',
+    'column',
     'copy-to-clipboard',
     'hero',
     'hero-heading',
     'hero-subheading',
     'image',
+    'row',
     'video'
   ].join('|');
 
@@ -47,6 +49,47 @@ async function renameDeprecatedComponents() {
   }
 }
 
+async function updateStacheImportPaths() {
+  const results = await findInFiles.find(
+    {
+      term: '(\'|")(@blackbaud/stache/?[A-z0-9/\\-\\.]*)(\'|")',
+      flags: 'g'
+    },
+    'src',
+    '\\.ts$'
+  );
+
+  for (const fileName of Object.keys(results)) {
+    const matches = results[fileName].matches;
+
+    let fileContents = await fs.readFile(
+      fileName,
+      'utf8'
+    );
+
+    matches.forEach((match) => {
+      const replacement = '\'@blackbaud/skyux-lib-stache\'';
+
+      logger.info(`Updating import path from \`${match}\` to \`${replacement}\` in ${fileName}.`);
+
+      fileContents = fileContents.replace(
+        match,
+        replacement
+      );
+    });
+
+    await fs.writeFile(fileName, fileContents);
+  }
+
+}
+
+function modifyDependencies(dependencies, devDependencies) {
+  dependencies['@blackbaud/skyux-lib-stache'] = 'latest';
+  devDependencies['@blackbaud/skyux-builder-stache-search'] = 'latest';
+}
+
 module.exports = {
-  renameDeprecatedComponents
+  modifyDependencies,
+  renameDeprecatedComponents,
+  updateStacheImportPaths
 };

--- a/lib/stache.js
+++ b/lib/stache.js
@@ -1,0 +1,52 @@
+const logger = require('@blackbaud/skyux-logger');
+const findInFiles = require('find-in-files');
+const fs = require('fs-extra');
+
+async function renameDeprecatedComponents() {
+
+  const componentSelectors = [
+    'code',
+    'code-block',
+    'copy-to-clipboard',
+    'hero',
+    'hero-heading',
+    'hero-subheading',
+    'image',
+    'video'
+  ].join('|');
+
+  const results = await findInFiles.find(
+    {
+      term: `<\/?stache-(${componentSelectors})(\\s|>)`,
+      flags: 'g'
+    },
+    'src',
+    '\\.html$'
+  );
+
+  for (const fileName of Object.keys(results)) {
+    const matches = results[fileName].matches;
+
+    let fileContents = await fs.readFile(
+      fileName,
+      'utf8'
+    );
+
+    matches.forEach((match) => {
+      const replacement = match.replace(/stache/g, 'sky');
+
+      logger.info(`Renaming deprecated component from \`${match}\` to \`${replacement}\` in ${fileName}.`);
+
+      fileContents = fileContents.replace(
+        match,
+        replacement
+      );
+    });
+
+    await fs.writeFile(fileName, fileContents);
+  }
+}
+
+module.exports = {
+  renameDeprecatedComponents
+};

--- a/spec/lib/app-dependencies.spec.js
+++ b/spec/lib/app-dependencies.spec.js
@@ -163,6 +163,41 @@ describe('App dependencies', () => {
       expect(dependencies).toBeUndefined();
     });
 
+    it('should handle prerelease versions', async () => {
+      await appDependencies.upgradeDependencies({
+        'prerelease-foo': '1.0.0-rc.0'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith(
+        'prerelease-foo',
+        {
+          version: '^1.0.0-rc.0'
+        }
+      );
+
+      await appDependencies.upgradeDependencies({
+        'prerelease-foo': '1.0.0-alpha.0'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith(
+        'prerelease-foo',
+        {
+          version: '^1.0.0-alpha.0'
+        }
+      );
+
+      await appDependencies.upgradeDependencies({
+        'prerelease-foo': '1.0.0-beta.0'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith(
+        'prerelease-foo',
+        {
+          version: '^1.0.0-beta.0'
+        }
+      );
+    });
+
   });
 
   describe('addSkyPeerDependencies() method', () => {


### PR DESCRIPTION
Non-stache features:
- Peer dependency lookup is now recursive.
- Add Builder plugins as an option to the package map.
- Add support for prerelease versions when upgrading package versions.