### PR TITLE
Recursively check for peer dependencies

### DIFF
--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -53,6 +53,8 @@ async function setDependencyVersions(dependencies) {
  * @param {*} dependencies List of top-level dependencies.
  */
 async function addSkyPeerDependencies(dependencies) {
+  let foundNewDependency = false;
+
   if (dependencies) {
     const skyPackageNames = Object.keys(dependencies).filter(
       packageName => packageName.indexOf('@skyux/') === 0
@@ -70,6 +72,7 @@ async function addSkyPeerDependencies(dependencies) {
           if (!dependencies[peerDependency]) {
             logger.info(`Adding package ${peerDependency} since it is a peer dependency of ${packageJson.name}...`);
             dependencies[peerDependency] = 'latest';
+            foundNewDependency = true;
           }
         }
       }
@@ -79,6 +82,11 @@ async function addSkyPeerDependencies(dependencies) {
   }
 
   fixDependencyOrder(dependencies);
+
+  if (foundNewDependency) {
+    // New dependencies were added, so we need to run the peer check again.
+    await addSkyPeerDependencies(dependencies);
+  }
 }
 
 /**
@@ -102,6 +110,7 @@ async function createPackageJsonDependencies(packageList) {
     '@skyux/core': 'latest',
     '@skyux/http': 'latest',
     '@skyux/i18n': 'latest',
+    '@skyux/modals': 'latest',
     '@skyux/omnibar-interop': 'latest',
     '@skyux/router': 'latest',
     '@skyux/theme': 'latest',

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -56,9 +56,12 @@ async function addSkyPeerDependencies(dependencies) {
   let foundNewDependency = false;
 
   if (dependencies) {
-    const skyPackageNames = Object.keys(dependencies).filter(
-      packageName => packageName.indexOf('@skyux/') === 0
-    );
+    const skyPackageNames = Object.keys(dependencies).filter((packageName) => {
+      return (
+        packageName.indexOf('@skyux/') === 0 ||
+        packageName.indexOf('@blackbaud/skyux-lib-') === 0
+      );
+    });
 
     const peerPromises = skyPackageNames.map(
       packageName => getPackageJson(packageName)

--- a/lib/package-map.js
+++ b/lib/package-map.js
@@ -47,8 +47,7 @@ const packageMap = [
     package: '@skyux/assets',
     nonModuleMatches: [
       'SkyAppAssetsService'
-    ],
-
+    ]
   },
   {
     package: '@skyux/colorpicker',

--- a/spec/lib/app-dependencies.spec.js
+++ b/spec/lib/app-dependencies.spec.js
@@ -168,10 +168,26 @@ describe('App dependencies', () => {
   describe('addSkyPeerDependencies() method', () => {
 
     it('should add peer dependencies for SKY UX dependencies', async () => {
-      getPackageJsonMock.and.returnValue({
-        name: '@skyux/indicators',
-        peerDependencies: {
-          foo: '^9.8.0'
+      getPackageJsonMock.and.callFake((packageName) => {
+        switch (packageName) {
+          case '@skyux/indicators':
+            return {
+              name: '@skyux/indicators',
+              peerDependencies: {
+                '@skyux/foo': '^9.8.0'
+              }
+            };
+          case '@skyux/foo':
+            // Check that peers are getting added recursively
+            // (`@skyux/foo` requires a peer of `@skyux/bar`).
+            return {
+              name: '@skyux/foo',
+              peerDependencies: {
+                '@skyux/bar': '^9.8.0'
+              }
+            };
+          default:
+            return {};
         }
       });
 
@@ -183,8 +199,9 @@ describe('App dependencies', () => {
 
       expect(dependencies).toEqual(
         jasmine.objectContaining({
-          '@skyux/indicators': '9.8.7',
-          'foo': '9.8.7'
+          '@skyux/bar': '9.8.7',
+          '@skyux/foo': '9.8.7',
+          '@skyux/indicators': '9.8.7'
         })
       );
     });

--- a/spec/lib/app-dependencies.spec.js
+++ b/spec/lib/app-dependencies.spec.js
@@ -174,14 +174,14 @@ describe('App dependencies', () => {
             return {
               name: '@skyux/indicators',
               peerDependencies: {
-                '@skyux/foo': '^9.8.0'
+                '@blackbaud/skyux-lib-foo': '^9.8.0'
               }
             };
-          case '@skyux/foo':
+          case '@blackbaud/skyux-lib-foo':
             // Check that peers are getting added recursively
-            // (`@skyux/foo` requires a peer of `@skyux/bar`).
+            // (`@blackbaud/skyux-lib-foo` requires a peer of `@skyux/bar`).
             return {
-              name: '@skyux/foo',
+              name: '@blackbaud/skyux-lib-foo',
               peerDependencies: {
                 '@skyux/bar': '^9.8.0'
               }
@@ -200,7 +200,7 @@ describe('App dependencies', () => {
       expect(dependencies).toEqual(
         jasmine.objectContaining({
           '@skyux/bar': '9.8.7',
-          '@skyux/foo': '9.8.7',
+          '@blackbaud/skyux-lib-foo': '9.8.7',
           '@skyux/indicators': '9.8.7'
         })
       );

--- a/spec/lib/app-dependencies.spec.js
+++ b/spec/lib/app-dependencies.spec.js
@@ -186,6 +186,14 @@ describe('App dependencies', () => {
                 '@skyux/bar': '^9.8.0'
               }
             };
+          case '@skyux/bar':
+            // Confirm that circular peers do not cause an infinite loop.
+            return {
+              name: '@skyux/bar',
+              peerDependencies: {
+                '@blackbaud/skyux-lib-foo': '^9.8.0'
+              }
+            };
           default:
             return {};
         }


### PR DESCRIPTION
Currently, we're only getting peer dependencies from a single level; this change will check peers recursively.