### PR TITLE
Add support for recommended Builder plugins

### DIFF
--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -127,7 +127,6 @@ async function createPackageJsonDependencies(packageList) {
   for (const packageName of Object.keys(packageList)) {
     const packageConfig = packageMap.getPackage(packageName);
     const builderPlugins = packageConfig.builderPlugins;
-    console.log('BUILDER', builderPlugins); //eslint-disable-line
 
     // Add any Builder plugins to dev dependencies.
     if (builderPlugins) {

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -125,7 +125,18 @@ async function createPackageJsonDependencies(packageList) {
   };
 
   for (const packageName of Object.keys(packageList)) {
-    if (!packageMap.getPackage(packageName).skipInstall) {
+    const packageConfig = packageMap.getPackage(packageName);
+    const builderPlugins = packageConfig.builderPlugins;
+
+    // Add any Builder plugins to dev dependencies.
+    if (builderPlugins) {
+      builderPlugins.forEach((plugin) => {
+        delete dependencies[plugin];
+        devDependencies[plugin] = 'latest';
+      });
+    }
+
+    if (!packageConfig.skipInstall) {
       const dependenciesToUpdate = packageName.indexOf('@skyux-sdk/') === 0 ? devDependencies : dependencies;
 
       dependenciesToUpdate[packageName] = 'latest';

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -127,6 +127,7 @@ async function createPackageJsonDependencies(packageList) {
   for (const packageName of Object.keys(packageList)) {
     const packageConfig = packageMap.getPackage(packageName);
     const builderPlugins = packageConfig.builderPlugins;
+    console.log('BUILDER', builderPlugins); //eslint-disable-line
 
     // Add any Builder plugins to dev dependencies.
     if (builderPlugins) {

--- a/lib/skyux-config.js
+++ b/lib/skyux-config.js
@@ -1,5 +1,31 @@
 const jsonUtils = require('./json-utils');
 
+async function updatePlugins(config) {
+  const packageJson = await jsonUtils.readJson('package.json');
+
+  packageJson.devDependencies = packageJson.devDependencies || {};
+
+  const installedPlugins = Object.keys(packageJson.devDependencies).map((packageName) => {
+    return packageName;
+  }).filter((packageName) => {
+    return (
+      packageName.indexOf('@blackbaud/skyux-builder-plugin-') === 0 ||
+      packageName.indexOf('@skyux-sdk/builder-plugin-') === 0
+    );
+  });
+
+  // Update plugins array, from installed plugins.
+  if (!config.plugins) {
+    config.plugins = installedPlugins;
+  } else {
+    installedPlugins.forEach((plugin) => {
+      if (config.plugins.indexOf(plugin) === -1) {
+        config.plugins.push(plugin);
+      }
+    });
+  }
+}
+
 async function updateSkyuxConfig() {
   const config = await jsonUtils.readJson('skyuxconfig.json') || {};
 
@@ -21,6 +47,8 @@ async function updateSkyuxConfig() {
   if (newConfig.app.styles.indexOf(skyCssPath) < 0) {
     newConfig.app.styles.push(skyCssPath);
   }
+
+  await updatePlugins(newConfig);
 
   await jsonUtils.writeJson('skyuxconfig.json', newConfig);
 }

--- a/lib/skyux-config.js
+++ b/lib/skyux-config.js
@@ -5,9 +5,7 @@ async function updatePlugins(config) {
 
   packageJson.devDependencies = packageJson.devDependencies || {};
 
-  const installedPlugins = Object.keys(packageJson.devDependencies).map((packageName) => {
-    return packageName;
-  }).filter((packageName) => {
+  const installedPlugins = Object.keys(packageJson.devDependencies).filter((packageName) => {
     return (
       packageName.indexOf('@blackbaud/skyux-builder-plugin-') === 0 ||
       packageName.indexOf('@skyux-sdk/builder-plugin-') === 0

--- a/spec/lib/app-dependencies.spec.js
+++ b/spec/lib/app-dependencies.spec.js
@@ -89,13 +89,13 @@ describe('App dependencies', () => {
       );
     });
 
-    it('should skip installation of specified pacakges', async () => {
+    it('should skip installation of specified packages', async () => {
       getPackageJsonMock.and.returnValue({
         name: '@skyux/foo'
       });
 
       packageMapMock.getPackage.and.returnValue({
-        pacakge: '@skyux/foo',
+        package: '@skyux/foo',
         skipInstall: true
       });
 
@@ -111,6 +111,38 @@ describe('App dependencies', () => {
         })
       );
 
+    });
+
+    it('should add builder plugins from the package map', async () => {
+      getPackageJsonMock.and.returnValue({
+        name: '@skyux/indicators'
+      });
+
+      packageMapMock.getPackage.and.returnValue({
+        package: '@skyux/indicators',
+        builderPlugins: [
+          '@blackbaud/skyux-builder-plugin-foo',
+          '@skyux-sdk/builder-plugin-bar'
+        ]
+      });
+
+      const result = await appDependencies.createPackageJsonDependencies(
+        {
+          '@skyux/indicators': { }
+        }
+      );
+
+      expect(result).toEqual(
+        {
+          dependencies: jasmine.objectContaining({
+            '@skyux/indicators': '9.8.7'
+          }),
+          devDependencies: jasmine.objectContaining({
+            '@blackbaud/skyux-builder-plugin-foo': '9.8.7',
+            '@skyux-sdk/builder-plugin-bar': '9.8.7'
+          })
+        }
+      );
     });
 
   });

--- a/spec/lib/skyux-config.spec.js
+++ b/spec/lib/skyux-config.spec.js
@@ -4,7 +4,20 @@ describe('SKY UX config', () => {
   let jsonUtilsMock;
   let skyuxConfig;
 
+  let packageJsonMock;
+  let skyuxconfigMock;
+
   beforeEach(() => {
+    packageJsonMock = {};
+
+    skyuxconfigMock = {
+      app: {
+        styles: [
+          '@skyux/theme/css/sky.css'
+        ]
+      }
+    };
+
     jsonUtilsMock = {
       readJson: jasmine.createSpy('readJson'),
       writeJson: jasmine.createSpy('writeJson')
@@ -13,6 +26,16 @@ describe('SKY UX config', () => {
     mock('../../lib/json-utils', jsonUtilsMock);
 
     skyuxConfig = mock.reRequire('../../lib/skyux-config');
+
+    jsonUtilsMock.readJson.and.callFake((fileName) => {
+      switch (fileName) {
+        case 'skyuxconfig.json':
+          return skyuxconfigMock;
+
+        case 'package.json':
+          return packageJsonMock;
+      }
+    });
   });
 
   afterEach(() => {
@@ -20,9 +43,9 @@ describe('SKY UX config', () => {
   });
 
   it('should set the $schema property as the first property', async () => {
-    jsonUtilsMock.readJson.and.returnValue({
+    skyuxconfigMock = {
       auth: true
-    });
+    };
 
     await skyuxConfig.updateSkyuxConfig();
 
@@ -34,7 +57,7 @@ describe('SKY UX config', () => {
   });
 
   it('should add the SKY UX stylesheet if it is not present', async () => {
-    jsonUtilsMock.readJson.and.returnValue({});
+    skyuxconfigMock = {};
 
     await skyuxConfig.updateSkyuxConfig();
 
@@ -51,13 +74,13 @@ describe('SKY UX config', () => {
   });
 
   it('should not add the SKY UX stylesheet if it is already present', async () => {
-    jsonUtilsMock.readJson.and.returnValue({
+    skyuxconfigMock =  {
       app: {
         styles: [
           '@skyux/theme/css/sky.css'
         ]
       }
-    });
+    };
 
     await skyuxConfig.updateSkyuxConfig();
 
@@ -74,7 +97,7 @@ describe('SKY UX config', () => {
   });
 
   it('should handle a missing skyuxconfig.json file', async () => {
-    jsonUtilsMock.readJson.and.returnValue(undefined);
+    skyuxconfigMock = undefined;
 
     await skyuxConfig.updateSkyuxConfig();
 

--- a/spec/lib/skyux-config.spec.js
+++ b/spec/lib/skyux-config.spec.js
@@ -112,4 +112,60 @@ describe('SKY UX config', () => {
       })
     );
   });
+
+  it('should add plugins from package.json', async () => {
+    skyuxconfigMock = {};
+
+    packageJsonMock = {
+      devDependencies: {
+        '@blackbaud/skyux-builder-plugin-foo': '1.0.0',
+        '@skyux-sdk/builder-plugin-bar': '1.0.0',
+        'typescript': '3.0.0'
+      }
+    };
+
+    await skyuxConfig.updateSkyuxConfig();
+
+    expect(jsonUtilsMock.writeJson).toHaveBeenCalledWith(
+      'skyuxconfig.json',
+      jasmine.objectContaining({
+        plugins: [
+          '@blackbaud/skyux-builder-plugin-foo',
+          '@skyux-sdk/builder-plugin-bar'
+        ]
+      })
+    );
+  });
+
+  it('should add to existing plugins from package.json', async () => {
+    skyuxconfigMock = {
+      plugins: [
+        '@skyux-sdk/builder-plugin-existing',
+        '@skyux-sdk/builder-plugin-duplicate'
+      ]
+    };
+
+    packageJsonMock = {
+      devDependencies: {
+        '@blackbaud/skyux-builder-plugin-foo': '1.0.0',
+        '@skyux-sdk/builder-plugin-bar': '1.0.0',
+        '@skyux-sdk/builder-plugin-duplicate': '1.0.0',
+        'typescript': '3.0.0'
+      }
+    };
+
+    await skyuxConfig.updateSkyuxConfig();
+
+    expect(jsonUtilsMock.writeJson).toHaveBeenCalledWith(
+      'skyuxconfig.json',
+      jasmine.objectContaining({
+        plugins: [
+          '@skyux-sdk/builder-plugin-existing',
+          '@skyux-sdk/builder-plugin-duplicate',
+          '@blackbaud/skyux-builder-plugin-foo',
+          '@skyux-sdk/builder-plugin-bar'
+        ]
+      })
+    );
+  });
 });


### PR DESCRIPTION
- Add Builder plugins that are listed in `devDependencies` to **skyuxconfig.json**'s `plugins` array.
- Add Builder plugins to `devDependencies` that are listed in the **package-map.js** `builderPlugins` option. (This is helpful for consumers, if the library they are installing recommends a plugin, but does not have it listed in the library's dependencies.)

**package-map.js**

```
const packageMap = [
  {
    package: '@blackbaud/skyux-lib-stache',
    builderPlugins: [
      '@blackbaud/skyux-builder-plugin-stache'
    ]
  }
};
```