### PR TITLE
Add missing types for `@skyux/omnibar-interop`

### DIFF
--- a/lib/package-map.js
+++ b/lib/package-map.js
@@ -636,6 +636,14 @@ const packageMap = [
     ]
   },
   {
+    package: '@skyux/omnibar-interop',
+    nonModuleMatches: [
+      'SkyAppOmnibarProvider',
+      'SkyAppOmnibarReadyArgs',
+      'SkyAppSearchResultsProvider'
+    ]
+  },
+  {
     package: '@skyux/popovers',
     modules: [
       {


### PR DESCRIPTION
Issue: https://github.com/blackbaud/skyux-sdk-builder-plugin-migrate/issues/50