### PR TITLE
Install `@blackbaud/skyux-lib-code-block` if `<stache-markdown>` is found in templates

### DIFF
--- a/lib/package-map.js
+++ b/lib/package-map.js
@@ -22,14 +22,16 @@ const packageMap = [
         name: 'SkyCodeBlockModule',
         matches: [
           'SkyCodeBlockModule',
-          'sky-code-block'
+          'sky-code-block',
+          'stache-markdown' // Install the code block library if markdown is present.
         ]
       },
       {
         name: 'SkyCodeModule',
         matches: [
           'SkyCodeModule',
-          'sky-code'
+          'sky-code',
+          'stache-markdown' // Install the code block library if markdown is present.
         ]
       }
     ],


### PR DESCRIPTION
If a consumer uses triple-back-ticks (```) to generate a code block within the `<stache-markdown>` component, but does NOT also have a `<sky-code-block>` component anywhere in their source code, the plugin will not install the `@blackbaud/skyux-lib-code-block` library, causing build failures.

(I confirmed that this fix works locally.)